### PR TITLE
Added warnings and instructions to show that only one washing liquid type can be used

### DIFF
--- a/frontend_native/Pages/Dashboard.tsx
+++ b/frontend_native/Pages/Dashboard.tsx
@@ -176,8 +176,8 @@ const Dashboard = ({ route, navigation }: NativeStackScreenProps<any>) => {
             <ConfirmationModal
                 isOpen={showWashingWarning}
                 onClose={() => setShowWashingWarning(false)}
-                headline="Single Washing Solution Required"
-                text={`1. Each protocol can use only ONE washing liquid TYPE.\n2. We RECOMMEND recording the name of the washing solution in the Description field,when you will be saving the protocol. \n3. You may need to change the washing bottle during launch if necessary.`}
+                headline="Single Washing Liquid Required"
+                text={`1. Each protocol can use only ONE washing liquid TYPE.\n2. We RECOMMEND recording the name of the washing liquid in the Description field,when you will be saving the protocol. \n3. You may need to change the washing bottle during launch if necessary.`}
                 actionButtonText="Continue"
                 showCheckbox={true}
                 checkboxLabel="Don't show this message again"

--- a/frontend_native/Pages/Dashboard.tsx
+++ b/frontend_native/Pages/Dashboard.tsx
@@ -16,12 +16,35 @@ import { makeRequest } from '../common/util';
 import { Method } from 'axios';
 import { ProtocolDto } from 'common/dto/protocol.dto';
 import ListItem from './ProtocolList/ListItem';
+import ConfirmationModal from '../components/ConfirmationModal';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useUser } from '../contexts/UserContext';
 
 const Dashboard = ({ route, navigation }: NativeStackScreenProps<any>) => {
+    const { user } = useUser();
     const [protocolCount, setProtocolCount] = useState(0);
     const [liquidCount, setLiquidCount] = useState(0);
     const [jobCount, setJobCount] = useState(0);
     const [protocols, setProtocols] = useState([] as ProtocolDto[]);
+    const [showWashingWarning, setShowWashingWarning] = useState(false);
+    const [dontShowAgain, setDontShowAgain] = useState(false);
+
+    const getWarningStorageKey = () => `dontShowWashingWarning_${user?.id}`;
+
+    useEffect(() => {
+        // Проверяем при загрузке был ли checkbox отмечен ранее для этого пользователя
+        const checkWashingWarning = async () => {
+            const storageKey = getWarningStorageKey();
+            const dontShow = await AsyncStorage.getItem(storageKey);
+            if (dontShow === 'true') {
+                setDontShowAgain(true);
+            }
+        };
+
+        if (user?.id) {
+            checkWashingWarning();
+        }
+    }, [user?.id]);
 
     useEffect(() => {
         makeRequest('GET' as Method, '/protocols').then((response) => {
@@ -62,7 +85,15 @@ const Dashboard = ({ route, navigation }: NativeStackScreenProps<any>) => {
                         bg="#1F2832"
                         mt="$3"
                         mr="$1"
-                        onPress={() => navigation.navigate('Create protocol')}
+                        onPress={() => {
+                            if (dontShowAgain) {
+                                // Если checkbox был отмечен - прямо переходим
+                                navigation.navigate('Create protocol');
+                            } else {
+                                // Иначе показываем модал
+                                setShowWashingWarning(true);
+                            }
+                        }}
                         alignItems="center"
                         justifyContent="center"
                         height={48}
@@ -142,6 +173,29 @@ const Dashboard = ({ route, navigation }: NativeStackScreenProps<any>) => {
                     </VStack>
                 </VStack>
             </Box>
+            <ConfirmationModal
+                isOpen={showWashingWarning}
+                onClose={() => setShowWashingWarning(false)}
+                headline="Single Washing Solution Required"
+                text={`1. Each protocol can use only ONE washing liquid TYPE.\n2. We RECOMMEND recording the name of the washing solution in the Description field,when you will be saving the protocol. \n3. You may need to change the washing bottle during launch if necessary.`}
+                actionButtonText="Continue"
+                showCheckbox={true}
+                checkboxLabel="Don't show this message again"
+                checkboxValue={dontShowAgain}
+                onCheckboxChange={async (isChecked) => {
+                    setDontShowAgain(isChecked);
+                    const storageKey = getWarningStorageKey();
+                    if (isChecked) {
+                        await AsyncStorage.setItem(storageKey, 'true');
+                    } else {
+                        await AsyncStorage.removeItem(storageKey);
+                    }
+                }}
+                action={() => {
+                    setShowWashingWarning(false);
+                    navigation.navigate('Create protocol');
+                }}
+            />
         </MainContainer>
     );
 };

--- a/frontend_native/Pages/LaunchPage/Launch.tsx
+++ b/frontend_native/Pages/LaunchPage/Launch.tsx
@@ -334,6 +334,9 @@ export default function Launch({
                                 onCompletionChange={(allOn) =>
                                     setAllWashingSwitchesOn(allOn)
                                 }
+                                protocolDescription={
+                                    protocol?.metadata.description
+                                }
                             />
                         )}
                         {stage == LaunchStage.STEP_FOUR && (

--- a/frontend_native/Pages/LaunchPage/WashingLiquidsStep.tsx
+++ b/frontend_native/Pages/LaunchPage/WashingLiquidsStep.tsx
@@ -59,7 +59,7 @@ export function WashingLiquidsStep(props: {
                     <ActionConfirmationToggle
                         icon={Droplet}
                         number={1}
-                        toggleName="Washing buffer"
+                        toggleName="Washing liquid"
                         confirmedActionName="at least 250ml"
                         checked={washingChecked}
                         onToggle={() => setWashingChecked(!washingChecked)}

--- a/frontend_native/Pages/LaunchPage/WashingLiquidsStep.tsx
+++ b/frontend_native/Pages/LaunchPage/WashingLiquidsStep.tsx
@@ -4,6 +4,7 @@ import { Biohazard, Droplet, Trash } from 'lucide-react-native';
 
 export function WashingLiquidsStep(props: {
     onCompletionChange?: (allSwitchesOn: boolean) => void;
+    protocolDescription?: string;
 }) {
     const [washingChecked, setWashingChecked] = useState(false);
     const [generalWasteChecked, setGeneralWasteChecked] = useState(false);
@@ -36,14 +37,20 @@ export function WashingLiquidsStep(props: {
                             1. Open tray with washing liquids
                         </Text>
                         <Text mb={4} fontSize={12} color="black" opacity={0.5}>
-                            2. Check if there is enough washing liquid
+                            2. Check if washing liquid have the right name and
+                            type. If needed, change the liquid , by unscrewing
+                            the cap and replacing the liquid bottle with the
+                            correct one.
                         </Text>
                         <Text mb={4} fontSize={12} color="black" opacity={0.5}>
-                            3. If there is not enough liquid, insert liquids as
+                            3. Check if there is enough washing liquid
+                        </Text>
+                        <Text mb={4} fontSize={12} color="black" opacity={0.5}>
+                            4. If there is not enough liquid, insert liquids as
                             per instructions into the tray
                         </Text>
                         <Text mb={4} fontSize={12} color="black" opacity={0.5}>
-                            4. When done, close the tray with washing liquids
+                            5. When done, close the tray with washing liquids
                         </Text>
                     </Box>
                 </VStack>
@@ -57,6 +64,31 @@ export function WashingLiquidsStep(props: {
                         checked={washingChecked}
                         onToggle={() => setWashingChecked(!washingChecked)}
                     />
+                    {props.protocolDescription && (
+                        <Box
+                            bg="rgba(31, 40, 50, 0.05)"
+                            borderRadius={8}
+                            p="$3"
+                            mt="$3"
+                            borderWidth={1}
+                            borderColor="rgba(31, 40, 50, 0.1)"
+                        >
+                            <Text
+                                fontSize={12}
+                                color="#1F2832"
+                                fontFamily="Manrope-Medium"
+                            >
+                                <Text
+                                    fontSize={12}
+                                    fontFamily="Manrope-SemiBold"
+                                    color="#1F2832"
+                                >
+                                    Description:{' '}
+                                </Text>
+                                {props.protocolDescription}
+                            </Text>
+                        </Box>
+                    )}
                 </Box>
             </HStack>
 

--- a/frontend_native/Pages/ProtocolConstructor/AddStepForm.tsx
+++ b/frontend_native/Pages/ProtocolConstructor/AddStepForm.tsx
@@ -92,6 +92,23 @@ const SelectForm = ({
             <Text fontSize={16} opacity={0.5} color="black">
                 Add to step:
             </Text>
+            <Box
+                bg="rgba(98, 98, 98, 0.1)"
+                borderRadius={8}
+                p="$3"
+                borderWidth={1}
+                borderColor="rgba(0, 0, 0, 0.2)"
+                width={250}
+            >
+                <Text
+                    fontSize={12}
+                    color="rgba(0, 0, 0, 0.7)"
+                    fontFamily="Manrope-Medium"
+                    textAlign="center"
+                >
+                    One protocol can use only ONE type of washing liquid.
+                </Text>
+            </Box>
             <Button
                 bg="transparent"
                 width={250}

--- a/frontend_native/Pages/ProtocolConstructor/SaveProtocolModal.tsx
+++ b/frontend_native/Pages/ProtocolConstructor/SaveProtocolModal.tsx
@@ -341,7 +341,7 @@ const StepListItem = ({
     liquidMap: Map<number, string>;
 }) => {
     const liquidName = isWashing
-        ? 'Washing solution'
+        ? 'Washing'
         : liquidMap.get(step.applied_liquid_id) || 'Reagent';
     return (
         <HStack

--- a/frontend_native/Pages/ProtocolConstructor/SaveProtocolModal.tsx
+++ b/frontend_native/Pages/ProtocolConstructor/SaveProtocolModal.tsx
@@ -139,7 +139,8 @@ const SaveProtocolModal = ({
                                             color: AppStyles.color.text_primary,
                                         }}
                                     >
-                                        Description
+                                        Description ( Add washing liquid name
+                                        here )
                                     </Text>
                                     <Input
                                         borderWidth="$0"

--- a/frontend_native/Pages/ProtocolConstructor/StepGroup.tsx
+++ b/frontend_native/Pages/ProtocolConstructor/StepGroup.tsx
@@ -228,6 +228,7 @@ const StepGroup = ({
                     console.log(
                         `Rendering step ${JSON.stringify(step)} of group ${stepGroup.step_group.name}`,
                     );
+                    let currentIndex = stepIndex * 4 + 1;
                     return (
                         <>
                             {step.target_temperature > 2500 && (
@@ -245,7 +246,7 @@ const StepGroup = ({
                             )}
                             <Step
                                 key={`${stepGroup.step_group.sequence_number}-${step.id}-liquid`}
-                                index={stepIndex * 4 + 1}
+                                index={currentIndex}
                                 step={step}
                                 setStepGroups={setStepGroups}
                                 allStepGroups={allStepGroups}
@@ -258,7 +259,7 @@ const StepGroup = ({
                             {step.target_temperature > 2500 && (
                                 <Step
                                     key={`${stepGroup.step_group.sequence_number}-${step.id}-cooling`}
-                                    index={stepIndex * 4 + 2}
+                                    index={currentIndex + 1}
                                     step={step}
                                     setStepGroups={setStepGroups}
                                     allStepGroups={allStepGroups}
@@ -271,7 +272,11 @@ const StepGroup = ({
                             {step.washing_iterations > 0 && (
                                 <Step
                                     key={`${stepGroup.step_group.sequence_number}-${step.id}-wash`}
-                                    index={stepIndex * 4 + 3}
+                                    index={
+                                        step.target_temperature > 2500
+                                            ? currentIndex + 2
+                                            : currentIndex + 1
+                                    }
                                     step={step}
                                     setStepGroups={setStepGroups}
                                     allStepGroups={allStepGroups}

--- a/frontend_native/Pages/ProtocolConstructor/StepGroup.tsx
+++ b/frontend_native/Pages/ProtocolConstructor/StepGroup.tsx
@@ -46,7 +46,6 @@ const StepGroup = ({
         `activeStepGroup: ${activeStepGroup}, stepGroupId: ${stepGroup.step_group.name}`,
     );
 
-    let index = 0;
     return (
         <VStack>
             <ConfirmationModal
@@ -225,7 +224,7 @@ const StepGroup = ({
                 </HStack>
             </Pressable>
             <VStack gap={8} mt={24}>
-                {stepGroup.steps.map((step) => {
+                {stepGroup.steps.map((step, stepIndex) => {
                     console.log(
                         `Rendering step ${JSON.stringify(step)} of group ${stepGroup.step_group.name}`,
                     );
@@ -233,8 +232,8 @@ const StepGroup = ({
                         <>
                             {step.target_temperature > 2500 && (
                                 <Step
-                                    key={`h${index}`}
-                                    index={++index}
+                                    key={`${stepGroup.step_group.sequence_number}-${step.id}-heating`}
+                                    index={stepIndex * 4}
                                     step={step}
                                     setStepGroups={setStepGroups}
                                     allStepGroups={allStepGroups}
@@ -245,8 +244,8 @@ const StepGroup = ({
                                 />
                             )}
                             <Step
-                                key={`l${index}`}
-                                index={++index}
+                                key={`${stepGroup.step_group.sequence_number}-${step.id}-liquid`}
+                                index={stepIndex * 4 + 1}
                                 step={step}
                                 setStepGroups={setStepGroups}
                                 allStepGroups={allStepGroups}
@@ -258,8 +257,8 @@ const StepGroup = ({
                             />
                             {step.target_temperature > 2500 && (
                                 <Step
-                                    key={`c${index}`}
-                                    index={++index}
+                                    key={`${stepGroup.step_group.sequence_number}-${step.id}-cooling`}
+                                    index={stepIndex * 4 + 2}
                                     step={step}
                                     setStepGroups={setStepGroups}
                                     allStepGroups={allStepGroups}
@@ -271,8 +270,8 @@ const StepGroup = ({
                             )}
                             {step.washing_iterations > 0 && (
                                 <Step
-                                    key={`w${index}`}
-                                    index={++index}
+                                    key={`${stepGroup.step_group.sequence_number}-${step.id}-wash`}
+                                    index={stepIndex * 4 + 3}
                                     step={step}
                                     setStepGroups={setStepGroups}
                                     allStepGroups={allStepGroups}

--- a/frontend_native/Pages/ProtocolList/Header.tsx
+++ b/frontend_native/Pages/ProtocolList/Header.tsx
@@ -28,6 +28,7 @@ interface HeaderProps {
     onSort: (column: string) => void;
     sortColumn: string;
     sortDirection: 'asc' | 'desc';
+    onCreateProtocol?: () => void;
 }
 
 const Header = ({
@@ -43,6 +44,7 @@ const Header = ({
     onSort,
     sortColumn,
     sortDirection,
+    onCreateProtocol,
 }: HeaderProps) => {
     return (
         <VStack alignItems="flex-start" width="100%" space="lg" mt="$4">
@@ -70,7 +72,11 @@ const Header = ({
                     borderColor="$black"
                     bg="#1F2832"
                     ml="$2"
-                    onPress={() => navigation.navigate('Create protocol')}
+                    onPress={() =>
+                        onCreateProtocol
+                            ? onCreateProtocol()
+                            : navigation.navigate('Create protocol')
+                    }
                     alignItems="center"
                     justifyContent="center"
                     height={48}

--- a/frontend_native/Pages/ProtocolList/ProtocolList.tsx
+++ b/frontend_native/Pages/ProtocolList/ProtocolList.tsx
@@ -356,7 +356,7 @@ export default function ProtocolList({
             <ConfirmationModal
                 isOpen={showWashingWarning}
                 onClose={() => setShowWashingWarning(false)}
-                headline="Single Washing Solution Required"
+                headline="Single Washing Liquid Required"
                 text={`1. Each protocol can use only ONE washing liquid TYPE.\n2. We RECOMMEND recording the name of the washing liquid in the Description field ,when you will be saving the protocol. \n3. You may need to change the washing bottle during launch if necessary.`}
                 actionButtonText="Continue"
                 showCheckbox={true}

--- a/frontend_native/Pages/ProtocolList/ProtocolList.tsx
+++ b/frontend_native/Pages/ProtocolList/ProtocolList.tsx
@@ -26,11 +26,15 @@ import { X } from 'lucide-react-native';
 import ListItem from './ListItem';
 import Header from './Header';
 import EmptyListPlaceholder from './EmptyListPlaceholder';
+import ConfirmationModal from '../../components/ConfirmationModal';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useUser } from '../../contexts/UserContext';
 
 export default function ProtocolList({
     route,
     navigation,
 }: NativeStackScreenProps<any>) {
+    const { user } = useUser();
     const scrollViewRef = useRef<ScrollView>(null);
     const isFocused = useIsFocused();
     const [networkError, setNetworkError] = useState(false);
@@ -38,6 +42,8 @@ export default function ProtocolList({
     const [protocols, setProtocols] = useState<ProtocolDto[] | undefined>(
         undefined,
     );
+
+    const getWarningStorageKey = () => `dontShowWashingWarning_${user?.id}`;
 
     const listInitilizer = () => {
         setNetworkError(false);
@@ -78,6 +84,24 @@ export default function ProtocolList({
     const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
 
     const [active, setActive] = useState(false);
+    const [showWashingWarning, setShowWashingWarning] = useState(false);
+    const [dontShowAgain, setDontShowAgain] = useState(false);
+
+    // Проверяем при загрузке был ли checkbox отмечен ранее
+    useEffect(() => {
+        const checkWashingWarning = async () => {
+            const storageKey = getWarningStorageKey();
+            const dontShow = await AsyncStorage.getItem(storageKey);
+            if (dontShow === 'true') {
+                setDontShowAgain(true);
+            }
+        };
+
+        if (user?.id) {
+            checkWashingWarning();
+        }
+    }, [user?.id]);
+
     useEffect(() => {
         if (!protocols) return;
 
@@ -221,6 +245,15 @@ export default function ProtocolList({
                     onSort={handleSort}
                     sortColumn={sortColumn}
                     sortDirection={sortDirection}
+                    onCreateProtocol={() => {
+                        if (dontShowAgain) {
+                            // Если checkbox был отмечен - прямо переходим
+                            navigation.navigate('Create protocol');
+                        } else {
+                            // Иначе показываем модал
+                            setShowWashingWarning(true);
+                        }
+                    }}
                 />
                 <Box flex={9} width="100%" mt="0">
                     {protocols == undefined && (
@@ -320,6 +353,29 @@ export default function ProtocolList({
                     )}
                 </Box>
             </Box>
+            <ConfirmationModal
+                isOpen={showWashingWarning}
+                onClose={() => setShowWashingWarning(false)}
+                headline="Single Washing Solution Required"
+                text={`1. Each protocol can use only ONE washing liquid TYPE.\n2. We RECOMMEND recording the name of the washing liquid in the Description field ,when you will be saving the protocol. \n3. You may need to change the washing bottle during launch if necessary.`}
+                actionButtonText="Continue"
+                showCheckbox={true}
+                checkboxLabel="Don't show this message again"
+                checkboxValue={dontShowAgain}
+                onCheckboxChange={async (isChecked) => {
+                    setDontShowAgain(isChecked);
+                    const storageKey = getWarningStorageKey();
+                    if (isChecked) {
+                        await AsyncStorage.setItem(storageKey, 'true');
+                    } else {
+                        await AsyncStorage.removeItem(storageKey);
+                    }
+                }}
+                action={() => {
+                    setShowWashingWarning(false);
+                    navigation.navigate('Create protocol');
+                }}
+            />
         </MainContainer>
     );
 }

--- a/frontend_native/components/ConfirmationModal.tsx
+++ b/frontend_native/components/ConfirmationModal.tsx
@@ -7,6 +7,10 @@ import {
     Heading,
     Button,
     ButtonText,
+    Checkbox,
+    CheckboxIndicator,
+    CheckboxLabel,
+    HStack,
 } from '@gluestack-ui/themed';
 import { StyleSheet, Text } from 'react-native';
 import { AppStyles } from '../constants/styles';
@@ -19,6 +23,10 @@ type TonesModalProps = {
     headline: string;
     text: string;
     actionButtonText: string;
+    showCheckbox?: boolean;
+    checkboxLabel?: string;
+    checkboxValue?: boolean;
+    onCheckboxChange?: (value: boolean) => void;
 };
 
 export default function ConfirmationModal({
@@ -28,11 +36,15 @@ export default function ConfirmationModal({
     headline,
     text,
     actionButtonText,
+    showCheckbox,
+    checkboxLabel,
+    checkboxValue,
+    onCheckboxChange,
 }: TonesModalProps) {
     const s = StyleSheet.create({
         modal_container: {
             borderRadius: 24,
-            width: 476,
+            width: 500,
         },
         text_center: {
             textAlign: 'center',
@@ -85,6 +97,31 @@ export default function ConfirmationModal({
                         >
                             {text}
                         </Text>
+                        {showCheckbox && (
+                            <HStack
+                                mt="$4"
+                                alignItems="center"
+                                justifyContent="center"
+                            >
+                                <Checkbox
+                                    value={
+                                        checkboxValue ? 'checked' : 'unchecked'
+                                    }
+                                    onChange={(isChecked) => {
+                                        onCheckboxChange?.(isChecked);
+                                    }}
+                                >
+                                    <CheckboxIndicator mr="$2" />
+                                    <CheckboxLabel
+                                        fontSize={14}
+                                        fontFamily="Manrope-Medium"
+                                        color={AppStyles.color.text_primary}
+                                    >
+                                        {checkboxLabel || "Don't show again"}
+                                    </CheckboxLabel>
+                                </Checkbox>
+                            </HStack>
+                        )}
                     </ModalBody>
                     <ModalFooter>
                         <Button


### PR DESCRIPTION
1. Added a new modal window with a warning that only one type of washing can be used per protocol
2. Added a box with the same information to the protocol constructor
3. Added a recommendation to the Save Protocol modal window to include the washing name in the description
4. Added to launch 3 step new insrtuction about switching the washing type
5. Renamed "washing buffer and solution" to "washing" or "washing liquids" for better consistency
6. Fixed step numbering in the protocol constructor if no heating/cooling steps